### PR TITLE
fix(pages): remove index permalink '/' for project pages

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,6 @@ description: "コンピュータサイエンスを築いた天才たちの物語
 author: "株式会社アイティードゥ"
 version: "1.0.0"
 order: 1
-permalink: /
 ---
 
 # デジタル革命の先駆者たち


### PR DESCRIPTION
Project Pages require index at baseurl. Removing 'permalink: /' so index is served at /cs-visionaries-book/.