### PR TITLE
docs: add bottom navigation to root

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -127,3 +127,4 @@ ITコンサルティング・教育事業を展開。技術の本質を分かり
 ---
 
 Built with [Book Publishing Template v3.0](https://github.com/itdojp/book-publishing-template2)
+{% include page-navigation.html %}


### PR DESCRIPTION
Add bottom navigation include to docs/index.md so the root page shows prev/next/home controls.