### PR TITLE
fix: repair book-config.json invalid escapes

### DIFF
--- a/book-config.json
+++ b/book-config.json
@@ -42,9 +42,9 @@
     "Thumbs.db"
   ],
   "contentExcludePatterns": [
-    "<\!-- PRIVATE:",
-    "<\!-- TODO:",
-    "<\!-- DRAFT:"
+    "<!-- PRIVATE:",
+    "<!-- TODO:",
+    "<!-- DRAFT:"
   ],
   "build": {
     "outputDirectory": "docs",


### PR DESCRIPTION
`book-config.json` の `contentExcludePatterns` に不正なエスケープ（`<\!--`）が含まれており、JSONとしてパースできない状態だったため修正しました。

- `<\!--` → `<!--` に修正（パターンの意図は維持）

生成・検証系のツールが `book-config.json` を読み込む前提で、最低限の健全性を回復します。
