### PR TITLE
docs: CLAUDE_TROUBLESHOOTING のラベル表記を整形

### DIFF
--- a/CLAUDE_TROUBLESHOOTING.md
+++ b/CLAUDE_TROUBLESHOOTING.md
@@ -46,7 +46,7 @@
 ### 2. GitHub Pages デプロイメント方式
 
 #### "Deploy from a branch" vs "GitHub Actions"
-- **違い**: 
+- **違い**
   - Branch: GitHubが自動的にJekyllビルド
   - Actions: カスタムビルドプロセスを使用可能
 - **選択基準**


### PR DESCRIPTION
## 変更内容
- `CLAUDE_TROUBLESHOOTING.md` のラベル行末尾のコロン（`:`）を削除し、表記を統一しました。

## 目的
- 箇条書きのラベル行を「見出し」として扱い、文末記号の揺れを減らします（Stage3: 表現・スタイル）。

## 影響範囲
- 表現のみ（内容・手順の意味は変更していません）。
