### PR TITLE
Issue #97: フッターのMIT単独表記を解消

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -677,7 +677,7 @@
                 </div>
             </div>
             <div class="footer-bottom">
-                <p>&copy; {{ 'now' | date: '%Y' }} {{ site.author.name }}. Content licensed under CC BY-NC-SA 4.0 (commercial use requires a separate agreement).</p>
+                <p>&copy; {{ 'now' | date: '%Y' }} {{ site.author.name | default: site.author }}. Content licensed under CC BY-NC-SA 4.0 (commercial use requires a separate agreement).</p>
                 <p>Published by <a href="https://itdo.jp">ITDO Inc.</a></p>
             </div>
         </div>


### PR DESCRIPTION
Issue #97（Issue #95 横展開）対応。\n\n- フッターに残っていた MIT License のデフォルト表示を削除し、CC BY-NC-SA 4.0（商用は別契約）を明示\n\n関連: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/97