### PR TITLE
fix(pages): stop deploying raw docs via actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build and Deploy
+name: Build
 
 on:
   push:
@@ -9,12 +9,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: "pages"
-  cancel-in-progress: true
 
 jobs:
   build:
@@ -41,27 +35,3 @@ jobs:
     - name: Build book
       run: |
         npm run build
-        
-    - name: Upload artifact
-      if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
-      uses: actions/upload-pages-artifact@v3
-      with:
-        path: ./docs
-
-  deploy:
-    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
-    needs: build
-    runs-on: ubuntu-latest
-    
-    permissions:
-      pages: write
-      id-token: write
-      
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-      
-    steps:
-    - name: Deploy to GitHub Pages
-      id: deployment
-      uses: actions/deploy-pages@v4


### PR DESCRIPTION
## 背景
GitHub Pages のトップ（`https://itdojp.github.io/cs-visionaries-book/`）が 404 になっていました。

## 原因
`.github/workflows/build.yml` が `actions/upload-pages-artifact` / `actions/deploy-pages` で `./docs`（Jekyll のソース: markdown 等）をそのまま GitHub Pages にデプロイしており、`index.html` が存在しないためトップが 404 になっていました。

## 対応
- Actions による Pages デプロイを停止し、CI は `npm run check-conflicts` / `npm run build` のみ実行
- Pages はリポジトリ設定の legacy build（`main:/docs`）に委譲

## 確認
- マージ後に `https://itdojp.github.io/cs-visionaries-book/` が 200 で表示できることを確認してください。

## 補足
将来的に Actions で Pages をデプロイする場合は、Jekyll ビルド成果物（通常は `_site`）を artifact としてアップロードする必要があります。
