### PR TITLE
fix(docs): repair integration checklist links

### DIFF
--- a/INTEGRATION_CHECKLIST.md
+++ b/INTEGRATION_CHECKLIST.md
@@ -1,8 +1,8 @@
 # Template Integration Checklist
 
-> ⚠️ **Note**: This checklist is for v2.0 of the book-publishing-template which uses a simplified single-repository architecture.
+> ⚠️ **Note**: This checklist targets the single-repository book template workflow (build output published via GitHub Pages).
 
-Use this checklist to track your book-publishing-template v2.0 integration progress.
+Use this checklist to track your template integration progress.
 
 ## 📋 Integration Status
 
@@ -84,6 +84,6 @@ Follow the [Quick Start](QUICK-START.md) to begin writing.
 ## 📚 Documentation References
 
 - [Quick Start](QUICK-START.md) - Quick local development and preview setup
-- [Template Guide](book-template-guide.md) - Complete template guide (features, structure, workflows, and checklists)
+- [Template Guide](book-template-guide.md) - Template overview (features, structure, and general usage)
 - [GitHub Pages Setup](GITHUB-PAGES-SETUP.md) - GitHub Pages deployment and setup
 - [Changelog](CHANGELOG.md) - Template updates and integration tracking


### PR DESCRIPTION
目的: INTEGRATION_CHECKLIST.md の存在しない参照（setup-guide.md / template-structure.md / TROUBLESHOOTING.md）を解消。

対応内容:
- QUICK-START.md / book-template-guide.md / GITHUB-PAGES-SETUP.md を参照するよう更新

確認:
- check-links: brokenLinks=0（book-formatter/scripts/check-links.js）

関連:
- https://github.com/itdojp/it-engineer-knowledge-architecture/issues/102
