### PR TITLE
docs: update Dockerfile example to Ubuntu 24.04

### DIFF
--- a/docs/chapters/chapter13.md
+++ b/docs/chapters/chapter13.md
@@ -615,7 +615,7 @@ Git時代：
 **Docker によるアプリケーション配布の革命**
 ```dockerfile
 # Dockerfile の例
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 RUN apt-get update && apt-get install -y python3
 COPY app.py /app/
 WORKDIR /app


### PR DESCRIPTION
## 変更内容\n- Dockerfile例のベースイメージを Ubuntu 24.04 に更新（20.04を削除）\n\n## 背景\n- 『20.04向け手順は削除して22.04/24.04のみ残す』方針に合わせる。\n\n## 影響範囲\n- ドキュメント記述のみ\n\n## 確認\n- Book QA/CI にて確認