### PR TITLE
Remove git add -A instructions

### DIFF
--- a/QUICK-START.md
+++ b/QUICK-START.md
@@ -32,7 +32,8 @@ npm run preview
 ### Step 4: GitHubへプッシュ
 
 ```bash
-git add -A
+git status
+git add -p  # または: git add <ファイル/ディレクトリ>
 git commit -m "Initial commit"
 # GitHubでリポジトリを作成後
 # git remote add origin https://github.com/yourusername/my-book.git

--- a/REPOSITORY-ACCESS-GUIDE.md
+++ b/REPOSITORY-ACCESS-GUIDE.md
@@ -154,7 +154,8 @@ node easy-setup.js
 npm run build
 
 # 4. Gitにコミット
-git add -A
+git status
+git add -p  # または: git add <ファイル/ディレクトリ>
 git commit -m "Initial commit"
 
 # 5. GitHubにリポジトリ作成してプッシュ

--- a/easy-setup.js
+++ b/easy-setup.js
@@ -331,7 +331,10 @@ ${this.config.title}へようこそ。
     console.log('==========================================');
     console.log(colors.blue('次のステップ:'));
     console.log('1. ' + colors.yellow('npm run build') + ' でコンテンツをビルド');
-    console.log('2. ' + colors.yellow('git add -A && git commit -m "Initial commit"'));
+    console.log('2. Gitにコミット（変更を確認してステージ）');
+    console.log('   ' + colors.yellow('git status'));
+    console.log('   ' + colors.yellow('git add -p') + '  # または: git add <ファイル/ディレクトリ>');
+    console.log('   ' + colors.yellow('git commit -m "Initial commit"'));
     console.log('3. GitHubにリポジトリを作成してプッシュ');
     console.log('4. Settings > Pages > Source: main branch /docs folder');
     console.log('\n詳細は README.md を参照してください。');


### PR DESCRIPTION
ユーザーポリシーに従い、ドキュメント/セットアップ出力に含まれる `git add -A` 指示を、より安全なステージ手順に置換しました。

- 置換内容: `git status` → `git add -p`（または `git add <ファイル/ディレクトリ>`）→ `git commit`
- 対象: `QUICK-START.md`, `REPOSITORY-ACCESS-GUIDE.md`, `easy-setup.js`
