### PR TITLE
fix: align font variables and runtime script references

### DIFF
--- a/docs/_layouts/book.html
+++ b/docs/_layouts/book.html
@@ -178,6 +178,5 @@
     <script src="{{ '/assets/js/sidebar.js' | relative_url }}"></script>
     <script src="{{ '/assets/js/search.js' | relative_url }}"></script>
     <script src="{{ '/assets/js/code-copy.js' | relative_url }}"></script>
-    <script src="{{ '/assets/js/safe-main.js' | relative_url }}"></script>
 </body>
 </html>

--- a/docs/assets/css/main.css
+++ b/docs/assets/css/main.css
@@ -33,8 +33,10 @@
   --color-syntax-number: #005cc5;
 
   /* Typography */
-  --font-family-base: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif;
-  --font-family-mono: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --font-mono: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+  --font-family-base: var(--font-sans);
+  --font-family-mono: var(--font-mono);
   --font-family-heading: var(--font-family-base);
 
   /* Font Sizes - Responsive */

--- a/templates/js/code-copy.js
+++ b/templates/js/code-copy.js
@@ -378,9 +378,9 @@ const copyStyles = `
 `;
 
 // Inject styles
-const styleSheet = document.createElement('style');
-styleSheet.textContent = copyStyles;
-document.head.appendChild(styleSheet);
+const copyStyleSheet = document.createElement('style');
+copyStyleSheet.textContent = copyStyles;
+document.head.appendChild(copyStyleSheet);
 
 // Initialize when DOM is ready
 if (document.readyState === 'loading') {

--- a/templates/js/sidebar.js
+++ b/templates/js/sidebar.js
@@ -241,9 +241,9 @@ const overlayStyles = `
 `;
 
 // Inject overlay styles
-const styleSheet = document.createElement('style');
-styleSheet.textContent = overlayStyles;
-document.head.appendChild(styleSheet);
+const sidebarStyleSheet = document.createElement('style');
+sidebarStyleSheet.textContent = overlayStyles;
+document.head.appendChild(sidebarStyleSheet);
 
 // Initialize sidebar manager when DOM is ready
 if (document.readyState === 'loading') {

--- a/templates/styles/main.css
+++ b/templates/styles/main.css
@@ -33,8 +33,10 @@
   --color-syntax-number: #005cc5;
   
   /* Typography */
-  --font-family-base: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif;
-  --font-family-mono: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --font-mono: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+  --font-family-base: var(--font-sans);
+  --font-family-mono: var(--font-mono);
   --font-family-heading: var(--font-family-base);
   
   /* Font Sizes - Responsive */


### PR DESCRIPTION
## Summary

Font/readability follow-up for itdojp/it-engineer-knowledge-architecture#117.

The current Pages Visual Check against the 39-book registry found that this book fails the shared font/runtime gate on mobile device emulation. This PR applies the minimal published-site/runtime alignment needed for the check to pass after Pages redeploys.

## Changes

- Add shared `--font-sans` / `--font-mono` CSS variables and route the legacy font-family variables through them
- Remove the stale `safe-main.js` layout reference from published `docs/_layouts/book.html`

## Validation

- `git diff --check`
- Static font/runtime smoke:
  - `docs/assets/css/main.css` and `templates/styles/main.css` contain `--font-sans` / `--font-mono`
  - `docs/_layouts/book.html` no longer references `safe-main.js`
  - runtime script files no longer declare global `const styleSheet`
- `BUNDLE_GEMFILE=$PWD/docs/Gemfile BUNDLE_PATH=/home/devuser/work/CodeX/booksB/.codex-local/tmp/bundle-cs-visionaries-book bundle exec jekyll build --source docs --destination /home/devuser/work/CodeX/booksB/.codex-local/tmp/cs-visionaries-book-font-fix-site --baseurl /cs-visionaries-book` succeeded

## Notes

- This PR is intentionally scoped to the visual-check failures observed from the Knowledge Architecture cross-book run. Content changes are out of scope.
- A follow-up Pages Visual Check will be run from `it-engineer-knowledge-architecture#117` after merge.
