### PR TITLE
[codex] constrain mobile layout overflow

### DIFF
--- a/docs/assets/css/main.css
+++ b/docs/assets/css/main.css
@@ -192,6 +192,7 @@ body {
 .book-layout {
   display: flex;
   min-height: 100vh;
+  min-width: 0;
 }
 
 .book-header {
@@ -227,12 +228,21 @@ body {
   margin-left: var(--sidebar-width);
   margin-top: var(--header-height);
   min-height: calc(100vh - var(--header-height));
+  min-width: 0;
 }
 
 .book-content {
+  width: 100%;
   max-width: var(--content-max-width);
   margin: 0 auto;
   padding: var(--space-8) var(--space-6);
+  min-width: 0;
+}
+
+.page-content {
+  min-width: 0;
+  max-width: 100%;
+  overflow-wrap: break-word;
 }
 
 /* Typography */
@@ -334,6 +344,8 @@ pre {
   overflow-x: auto;
   margin: var(--space-4) 0;
   line-height: var(--line-height-normal);
+  max-width: 100%;
+  min-width: 0;
 }
 
 pre code {
@@ -489,6 +501,7 @@ img {
   display: flex;
   align-items: center;
   gap: var(--space-3);
+  min-width: 0;
 }
 
 .header-center {
@@ -504,6 +517,7 @@ img {
 .header-title {
   color: var(--color-text-primary);
   text-decoration: none;
+  min-width: 0;
 }
 
 .header-title h1 {
@@ -511,6 +525,9 @@ img {
   padding: 0;
   border: 0;
   font-size: var(--font-size-xl);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .sidebar-toggle,
@@ -719,6 +736,8 @@ img {
 .code-block-wrapper {
   position: relative;
   margin: var(--space-4) 0;
+  max-width: 100%;
+  min-width: 0;
 }
 
 .code-copy-button {

--- a/templates/styles/main.css
+++ b/templates/styles/main.css
@@ -163,6 +163,7 @@ body {
 .book-layout {
   display: flex;
   min-height: 100vh;
+  min-width: 0;
 }
 
 .book-header {
@@ -198,12 +199,21 @@ body {
   margin-left: var(--sidebar-width);
   margin-top: var(--header-height);
   min-height: calc(100vh - var(--header-height));
+  min-width: 0;
 }
 
 .book-content {
+  width: 100%;
   max-width: var(--content-max-width);
   margin: 0 auto;
   padding: var(--space-8) var(--space-6);
+  min-width: 0;
+}
+
+.page-content {
+  min-width: 0;
+  max-width: 100%;
+  overflow-wrap: break-word;
 }
 
 /* Typography */
@@ -305,6 +315,8 @@ pre {
   overflow-x: auto;
   margin: var(--space-4) 0;
   line-height: var(--line-height-normal);
+  max-width: 100%;
+  min-width: 0;
 }
 
 pre code {


### PR DESCRIPTION
## Summary
- Constrain the main flex layout, content area, and code wrappers so long `pre` / Mermaid blocks do not expand the mobile viewport.
- Add defensive `min-width: 0` / `max-width: 100%` rules to the committed docs CSS.
- Mirror the core layout constraints in `templates/styles/main.css` so future regeneration keeps the mobile overflow fix.

## Context
- Closes #164
- Related: itdojp/it-engineer-knowledge-architecture#117
- The portfolio E2E follow-up reported horizontal overflow warnings for `cs-visionaries-book` on Pixel 7 / iPhone 13 equivalent checks.
- Root cause observed locally: `.book-main` remained a flex item with default `min-width: auto`, so long code / Mermaid blocks widened `.book-content`, fixed header, and overlay beyond the mobile viewport.

## Validation
- `git diff --check`
- `npm run check-conflicts`
- `npm run build` (passed; build-generated working tree noise was discarded before committing the focused CSS fix)
- `BUNDLE_GEMFILE=$PWD/docs/Gemfile BUNDLE_PATH=/home/devuser/work/CodeX/booksB/.codex-local/tmp/bundle-cs-visionaries-overflow bundle exec jekyll build --config docs/_config.yml --source docs --layouts docs/_layouts --destination /home/devuser/work/CodeX/booksB/.codex-local/tmp/cs-visionaries-overflow-site2 --baseurl /cs-visionaries-book`
- Local Playwright overflow smoke on root / chapter01 / chapter07 / chapter12 with Pixel 7 and iPhone 13 profiles: all document `overflow=0`
- Book formatter checks over `docs`: Unicode, textlint, internal links, layout risk, and markdown structure all passed

auto-generated-by: codex