### PR TITLE
UX flagsを公開Quick Startと図表索引実体へ整合

### DIFF
--- a/book-config.json
+++ b/book-config.json
@@ -74,12 +74,12 @@
   "ux": {
     "profile": "C",
     "modules": {
-      "quickStart": false,
+      "quickStart": true,
       "readingGuide": true,
       "checklistPack": false,
       "troubleshootingFlow": false,
       "conceptMap": true,
-      "figureIndex": true,
+      "figureIndex": false,
       "legalNotice": false,
       "glossary": true
     }


### PR DESCRIPTION
## 概要

公開Pagesのreader-facing実体に合わせてUX flagsを補正します。

## 変更

- 公開トップの専用「クイックスタート」見出し・最短読書routeに基づき`quickStart=true`
- 専用図表索引がないため`figureIndex=false`
- 実体のあるreading guide、付録D概念図、付録B用語解説は維持

## 検証

- `node scripts/check-metadata-consistency.js`
- `npm ci --omit=optional --ignore-scripts`
- `npm run lint:light`
- `npm run check:security`
- `git diff --check`

Closes #172
