### PR TITLE
chore: configure-pagesをNode.js 24対応v6へ更新する

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -86,7 +86,7 @@ jobs:
           path: ${{ runner.temp }}/layout-risk-report.json
           if-no-files-found: ignore
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Build (Jekyll; GitHub Pages compatible)
         uses: actions/jekyll-build-pages@v1


### PR DESCRIPTION
## Summary

- update active .github/workflows/book-qa.yml from actions/configure-pages@v5 to the Node.js 24-compatible @v6
- leave disabled/archive workflows, other Actions, Node runtime, permissions, Jekyll inputs, and book content unchanged

## Why

The current Book QA run emits the GitHub Actions Node.js 20 deprecation annotation for repository-managed configure-pages@v5. The shared owner was updated first in itdojp/book-formatter#105; this PR applies the repository-local minimum change.

GitHub Pages remains a GitHub-managed legacy deployment (main:/docs). Any annotation emitted only by pages-build-deployment is tracked separately in the parent Issue.

## Verification

- final head: b0059969b5acf2c317107e8ba70a7717ba746b87
- actionlint 1.7.12 on modified book-qa.yml: success
- npm ci / npm audit 0 / metadata / conflict check / test:light / Jekyll build: success; existing non-blocking Jekyll warning remains tracked by #175
- git diff --check: success
- active configure-pages@v5: 0; @v6: 1
- repository-wide actionlint reports two pre-existing shellcheck findings in unmodified nav-link-check.yml; this PR does not broaden scope to that file
- separate existing backlog: #175

Closes #176
Related: itdojp/it-engineer-knowledge-architecture#258
